### PR TITLE
Reduce concurrent collections

### DIFF
--- a/store.go
+++ b/store.go
@@ -99,6 +99,9 @@ func (s *memoryStore) collect() {
 	now := time.Now()
 	s.Lock()
 	defer s.Unlock()
+	if s.numStored == 0 {
+		return
+	}
 	s.numStored = 0
 	for e := s.idByTime.Front(); e != nil; {
 		ev, ok := e.Value.(idByTimeValue)


### PR DESCRIPTION
'memoryStore.collect()' may run concurrently, and we can return immediately when it is collecting by checking 'numStored' value.